### PR TITLE
Add --exclude_users_from_culling to cull_idle_servers.py

### DIFF
--- a/images/hub/cull_idle_servers.py
+++ b/images/hub/cull_idle_servers.py
@@ -249,7 +249,7 @@ def cull_idle(url, api_token, inactive_limit, cull_users=False, exclude_users_fr
             inactive = age
 
         should_cull = (inactive is not None and
-                       not exclude_users_from_culling and
+                       not exclude_user_from_culling and
                        inactive.total_seconds() >= inactive_limit)
         if should_cull:
             app_log.info(

--- a/images/hub/cull_idle_servers.py
+++ b/images/hub/cull_idle_servers.py
@@ -248,9 +248,9 @@ def cull_idle(url, api_token, inactive_limit, cull_users=False, exclude_users_fr
             # which introduces the 'created' field which is never None
             inactive = age
 
-        should_cull = (inactive is not None and
-                       not exclude_user_from_culling and
-                       inactive.total_seconds() >= inactive_limit)
+        should_cull = ((inactive is not None) and
+                       (not exclude_user_from_culling) and
+                       (inactive.total_seconds() >= inactive_limit))
         if should_cull:
             app_log.info(
                 "Culling user %s (inactive for %s)",

--- a/images/hub/jupyterhub_config.py
+++ b/images/hub/jupyterhub_config.py
@@ -369,6 +369,10 @@ if get_config('cull.enabled', False):
     if cull_max_age:
         cull_cmd.append('--max-age=%s' % cull_max_age)
 
+    exclude_users_from_culling = get_config('cull.excludeUsersFromCulling')
+    if exclude_users_from_culling:
+        cull_cmd.append('--exclude-users-from-culling=%s' % exclude_users_from_culling)
+
     c.JupyterHub.services.append({
         'name': 'cull-idle',
         'admin': True,


### PR DESCRIPTION
I'd like to enable to idle culler, and in particular enable `cull_users=True`, but prevent culling some administrative user(s).

For internal use, this adds `--exclude_users_from_culling` to `cull_idle_servers.py` against the latest stable tag, `0.8.2` (per [JupyterHub Helm chart reference](https://github.com/jupyterhub/helm-chart#the-jupyterhub-helm-chart)).

This PR should also produce a different tag, for internal usage, of the `jupyterhub/k8s-hub` image containing this updated `cull_idle_servers.py`, so that I can select that image in our z2jh Helm yaml.

https://hub.docker.com/layers/jupyterhub/k8s-hub/0.8.2/images/sha256-0492ebf6917e3da9a8c8ce35d4e014769f469271b724a58b0823cba7bee066ce?context=explore

https://github.com/jupyterhub/zero-to-jupyterhub-k8s/blob/0.8.2/jupyterhub/values.yaml#L45-L47


### Releasing

```
cd zero-to-jupyterhub-k8s/images/hub
docker build -t minervaproject/k8s-hub .
docker push minervaproject/k8s-hub
```